### PR TITLE
Remove calls to 'phpinvoice' class

### DIFF
--- a/examples/change_timezone.php
+++ b/examples/change_timezone.php
@@ -1,6 +1,6 @@
 <?php
 include('../InvoicePrinter.php');
-$invoice = new phpinvoice();
+$invoice = new InvoicePrinter();
   /* Header Settings */
   $invoice->setTimeZone('America/Los_Angeles');
   $invoice->setLogo("images/example2.png");

--- a/examples/example1.php
+++ b/examples/example1.php
@@ -1,6 +1,6 @@
 <?php
 include('../InvoicePrinter.php');
-$invoice = new phpinvoice();
+$invoice = new InvoicePrinter();
   /* Header Settings */
   $invoice->setLogo("images/sample1.jpg");
   $invoice->setColor("#007fff");

--- a/examples/example2.php
+++ b/examples/example2.php
@@ -1,6 +1,6 @@
 <?php
 include('../InvoicePrinter.php');
-$invoice = new phpinvoice();
+$invoice = new InvoicePrinter();
   /* Header Settings */
   $invoice->setLogo("images/example3.jpg");
   $invoice->setColor("#AA3939");

--- a/examples/simple.php
+++ b/examples/simple.php
@@ -1,6 +1,6 @@
 <?php
 include('../InvoicePrinter.php');
-$invoice = new phpinvoice();
+$invoice = new InvoicePrinter();
   /* Header Settings */
   $invoice->setLogo("images/simple_sample.png");
   $invoice->setColor("#677a1a");

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -458,7 +458,7 @@ class InvoicePrinter extends FPDF
             foreach ($this->items as $item) {
                 if ($item['description']) {
                     //Precalculate height
-                    $calculateHeight = new phpinvoice;
+                    $calculateHeight = new self;
                     $calculateHeight->addPage();
                     $calculateHeight->setXY(0, 0);
                     $calculateHeight->SetFont($this->font, '', 7);


### PR DESCRIPTION
I tried using this package (thanks!) for a quick project and found this problem. I couldn't open an issue so I'm filing a PR directly.

The InvoicePrinter class was using the original package's class name "phpinvoice", which threw an error because that class can not be found. 

This PR fixes that using 'self' instead. The examples have been updated accordingly as well.