### PR TITLE
Fix issues with some special characters like € or ° and in footer

### DIFF
--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -629,7 +629,7 @@ class InvoicePrinter extends FPDF
         $this->SetY(-$this->margins['t']);
         $this->SetFont($this->font, '', 8);
         $this->SetTextColor(50, 50, 50);
-        $this->Cell(0, 10, $this->footernote, 0, 0, 'L');
+        $this->Cell(0, 10, iconv("UTF-8", $this->charset,  $this->footernote), 0, 0, 'L');
         $this->Cell(0, 10, $this->lang['page'] . ' ' . $this->PageNo() . ' ' . $this->lang['page_of'] . ' {nb}', 0, 0,
             'R');
     }


### PR DESCRIPTION
Hi,

I had some troubles to use the € or ° symbol in the footer. I discovered that:

- iconv conversion is not applied on footer note,
- the use of charset windows-1252 is mandatory to get those symbols.

I introduced the ability to change the charset, but still use "ISO-8859-1" as default.

Regards,

Mickaël
