### PR TITLE
Fix count() on null when rendering informations (to and from)

### DIFF
--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -403,7 +403,7 @@ class InvoicePrinter extends FPDF
                 $this->SetFont($this->font, '', 8);
                 $this->SetTextColor(100, 100, 100);
                 $this->Ln(7);
-                for ($i = 1; $i < max(count($this->from), count($this->to)); $i++) {
+                for ($i = 1; $i < max($this->from === null ? 0 : count($this->from), $this->to === null ? 0 : count($this->to)); $i++) {
                     $this->Cell($width, $lineheight, iconv("UTF-8", "ISO-8859-1", $this->from[$i]), 0, 0, 'L');
                     $this->Cell(0, $lineheight, iconv("UTF-8", "ISO-8859-1", $this->to[$i]), 0, 0, 'L');
                     $this->Ln(5);


### PR DESCRIPTION
Hi,

I'm proposing this PR so it could render pdf manually when using a framework like symfony.

$this->from and $this->to can be null, and therefore, fail to render.

```sh
Warning: count(): Parameter must be an array or an object that implements Countable line 406
```

```php
// ....

$invoice->AddPage();
$invoice->Body();
$invoice->AliasNbPages();

return new Response( $invoice->Output('S'), 200,
            [
                'Content-Type'          => 'application/pdf',
                'Content-Disposition'   => 'attachment; filename="render.pdf"'
            ]
);
```

