### PR TITLE
Update function render according to FPDF 1.81

### DIFF
--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -293,7 +293,7 @@ class InvoicePrinter extends FPDF
         $this->AddPage();
         $this->Body();
         $this->AliasNbPages();
-        $this->Output($name, $destination);
+        return $this->Output($destination, $name);
     }
 
     public function Header()


### PR DESCRIPTION
I created this PR because I noticed that render function:
- Does not return anything and therefore won't work with dest='S'.
- Parent method signature is Output($destination, $name) and not Output($name, $destination)

fpdf Output prototype is as follow Output($dest='', $name='', $isUTF8=false)

```php
public function render($name = '', $destination = '')
    {
        $this->AddPage();
        $this->Body();
        $this->AliasNbPages();
        return $this->Output($destination, $name);
    }
```

This would simplify usage of pdf-invoice with framework like symfony.

*THIS*
```php
return new Response($invoice->render('render.pdf', 'S'), 200,
            [
                'Content-Type'          => 'application/pdf',
                'Content-Disposition'   => 'attachment; filename="render.pdf"'
            ]
        );
```
*INSTEAD OF*
```php
// ....

$invoice->AddPage();
$invoice->Body();
$invoice->AliasNbPages();

return new Response( $invoice->Output('S'), 200,
            [
                'Content-Type'          => 'application/pdf',
                'Content-Disposition'   => 'attachment; filename="render.pdf"'
            ]
);
```
