### PR TITLE
Add missing `time` key to de.inc

### DIFF
--- a/inc/languages/de.inc
+++ b/inc/languages/de.inc
@@ -1,15 +1,16 @@
 <?php
-  $lang['number']		= 'Rechnungsnummer';
-  $lang['date']			= 'Rechnungsdatum';
-  $lang['due']			= 'Fälligkeitsdatum';
-  $lang['to']			  = 'Rechnungsempfänger';
-  $lang['from']			= 'Rechnung von';
-  $lang['product']	= 'Produkt';
-  $lang['qty']			= 'Menge';
-  $lang['price']		= 'Preis';
-  $lang['discount']	= 'Rabatt';
-  $lang['vat']			= 'MwSt';
-  $lang['total']		= 'Gesamtbetrag';
-  $lang['page']			= 'Seite';
-  $lang['page_of']	= 'von';
+  $lang['number']       = 'Rechnungsnummer';
+  $lang['date']         = 'Rechnungsdatum';
+  $lang['time']         = 'Rechnungs-Uhrzeit';
+  $lang['due']          = 'Fälligkeitsdatum';
+  $lang['to']           = 'Rechnungsempfänger';
+  $lang['from']         = 'Rechnung von';
+  $lang['product']      = 'Produkt';
+  $lang['qty']          = 'Menge';
+  $lang['price']        = 'Preis';
+  $lang['discount']     = 'Rabatt';
+  $lang['vat']          = 'MwSt';
+  $lang['total']        = 'Gesamtbetrag';
+  $lang['page']         = 'Seite';
+  $lang['page_of']      = 'von';
 ?>


### PR DESCRIPTION
Never seen an invoice that states the time with the date, but anyways – adding that key to prevent `ErrorException: Undefined index: time`