### PR TITLE
Fix spanish translation

### DIFF
--- a/inc/languages/es.inc
+++ b/inc/languages/es.inc
@@ -1,7 +1,8 @@
 <?php
     $lang['number']   = 'Referencia';
     $lang['date']     = 'Fecha';
-    $lang['due']      = 'Facha de vencimiento';
+    $lang['due']      = 'Fecha de vencimiento';
+    $lang['time']     = 'Fecha de factura';
     $lang['to']       = 'Facturación a';
     $lang['from']     = 'Nuestra información ';
     $lang['product']  = 'Producto';


### PR DESCRIPTION
- Constructing InvoicePrinter with language setted to es would result into a Fatal error due to missing time variable.
- Fixed misspelled "Fecha".