### PR TITLE
French translation - Total without VAT

### DIFF
--- a/inc/languages/fr.inc
+++ b/inc/languages/fr.inc
@@ -10,6 +10,6 @@
     $lang['price']    = 'Prix unit. HT';
     $lang['discount'] = 'Réduction';
     $lang['vat']      = 'TVA';
-    $lang['total']    = 'Total TTC';
+    $lang['total']    = 'Total';
     $lang['page']     = 'Page';
     $lang['page_of']  = 'sur';


### PR DESCRIPTION
French translation for Total is the only language that mentions TTC which stands for VAT included. This is confusing if you use multi language invoices.