### PR TITLE
Option to add custom text or General Terms on new page

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,32 @@ Hide the issuer and client header row
 $invoice->hideToFromHeaders();
 ```
 
+### Add custom text or general terms
+
+Enable extra page with custom text, default is false
+
+```php
+$invoice->setAddTermsPage(true);
+```
+
+Define number of columns, default is 1
+
+```php
+$invoice->setAddTermsPageColumns(2);
+```
+
+Path to text file for 1 column
+
+```php
+$invoice->setAddTermsPageText1('example_terms01.txt');
+```
+
+Optional path to text file for 2nd column
+
+```php
+$invoice->setAddTermsPageText1('example_terms02.txt');
+```
+
 ### Adding Items
 
 Add a new product or service row to your document below the company and client information. PHP

--- a/examples/example_terms01.txt
+++ b/examples/example_terms01.txt
@@ -1,0 +1,1 @@
+My custom text for full width or left column

--- a/examples/example_terms02.txt
+++ b/examples/example_terms02.txt
@@ -1,0 +1,1 @@
+My custom text for right column

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -670,7 +670,7 @@ class InvoicePrinter extends FPDF
     }
 
     public function terms(){
-		if($this->addPageTermsColumns == 1){
+        if($this->addPageTermsColumns == 1){
             $txt = file_get_contents($this->addPageTermsText1);
             $this->SetY(10);
             $this->SetFont($this->font, 'b', 6);


### PR DESCRIPTION
With this option you can add your general terms of each invoice. It will be added to a new page without the header. I use a 2 column layout as it is multi-language, but you can also use the full width.