### PR TITLE
fix undefined offset exception; allow empty line in address lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,15 @@ $invoice = new InvoicePrinter($size, $currency, $language);
 How do you want to show your numbers?
 
 ```php
-$invoice->setNumberFormat($decimalpoint, $seperator);
+$invoice->setNumberFormat($decimalpoint, $seperator, $alignment, $space);
 ```
 
-| Parameter    | Type   | Accepts                     | Note                                       |
-|:-------------|:-------|:----------------------------|:-------------------------------------------|
-| decimalpoint | string | Commonly used is '.' or ',' | What string to use for decimal point       |
-| seperator    | string | Commonly used is '.' or ',' | What string to use for thousands separator |
+| Parameter    | Type    | Accepts                               | Note                                           |
+|:-------------|:--------|:--------------------------------------|:-----------------------------------------------|
+| decimalpoint | string  | Commonly used is '.' (default) or ',' | What string to use for decimal point           |
+| seperator    | string  | Commonly used is '.' or ',' (default) | What string to use for thousands separator     |
+| alignment    | string  | 'left' (default) or 'right'           | Where to show the currency symbol              |
+| space        | boolean | true (default) or false               | Show a space between currency symbol and price |
 
 ### Color
 

--- a/examples/change_timezone.php
+++ b/examples/change_timezone.php
@@ -1,33 +1,33 @@
 <?php
-include('../InvoicePrinter.php');
+
+include '../InvoicePrinter.php';
 $invoice = new InvoicePrinter();
   /* Header Settings */
   $invoice->setTimeZone('America/Los_Angeles');
-  $invoice->setLogo("images/example2.png");
-  $invoice->setColor("#f7540e");
-  $invoice->setType("Purchase Invoice");
-  $invoice->setReference("INV-55033645");
-  $invoice->setDate(date('M dS ,Y',time()));
-  $invoice->setDue(date('M dS ,Y',strtotime('+3 months')));
-  $invoice->setFrom(array("Seller Name","Sample Company Name","128 AA Juanita Ave","Glendora , CA 91740","United States of America"));
-  $invoice->setTo(array("Purchaser Name","Sample Company Name","128 AA Juanita Ave","Glendora , CA 91740","United States of America"));
+  $invoice->setLogo('images/example2.png');
+  $invoice->setColor('#f7540e');
+  $invoice->setType('Purchase Invoice');
+  $invoice->setReference('INV-55033645');
+  $invoice->setDate(date('M dS ,Y', time()));
+  $invoice->setDue(date('M dS ,Y', strtotime('+3 months')));
+  $invoice->setFrom(['Seller Name', 'Sample Company Name', '128 AA Juanita Ave', 'Glendora , CA 91740', 'United States of America']);
+  $invoice->setTo(['Purchaser Name', 'Sample Company Name', '128 AA Juanita Ave', 'Glendora , CA 91740', 'United States of America']);
   /* Adding Items in table */
-  $invoice->addItem("AMD Athlon X2DC-7450","2.4GHz/1GB/160GB/SMP-DVD/VB",6,0,580,0,3480);
-  $invoice->addItem("PDC-E5300","2.6GHz/1GB/320GB/SMP-DVD/FDD/VB",4,0,645,0,2580);
-  $invoice->addItem('LG 18.5" WLCD',"",10,0,230,0,2300);
-  $invoice->addItem("HP LaserJet 5200","",1,0,1100,0,1100);
+  $invoice->addItem('AMD Athlon X2DC-7450', '2.4GHz/1GB/160GB/SMP-DVD/VB', 6, 0, 580, 0, 3480);
+  $invoice->addItem('PDC-E5300', '2.6GHz/1GB/320GB/SMP-DVD/FDD/VB', 4, 0, 645, 0, 2580);
+  $invoice->addItem('LG 18.5" WLCD', '', 10, 0, 230, 0, 2300);
+  $invoice->addItem('HP LaserJet 5200', '', 1, 0, 1100, 0, 1100);
   /* Add totals */
-  $invoice->addTotal("Total",9460);
-  $invoice->addTotal("VAT 21%",1986.6);
-  $invoice->addTotal("Total due",11446.6,true);
-  /* Set badge */ 
-  $invoice->addBadge("Payment Paid");
+  $invoice->addTotal('Total', 9460);
+  $invoice->addTotal('VAT 21%', 1986.6);
+  $invoice->addTotal('Total due', 11446.6, true);
+  /* Set badge */
+  $invoice->addBadge('Payment Paid');
   /* Add title */
-  $invoice->addTitle("Important Notice");
+  $invoice->addTitle('Important Notice');
   /* Add Paragraph */
   $invoice->addParagraph("No item will be replaced or refunded if you don't have the invoice with you. You can refund within 2 days of purchase.");
   /* Set footer note */
-  $invoice->setFooternote("My Company Name Here");
+  $invoice->setFooternote('My Company Name Here');
   /* Render */
-  $invoice->render('timezone.pdf','I'); /* I => Display on browser, D => Force Download, F => local path save, S => return document path */
-?>
+  $invoice->render('timezone.pdf', 'I'); /* I => Display on browser, D => Force Download, F => local path save, S => return document path */

--- a/examples/example1.php
+++ b/examples/example1.php
@@ -1,33 +1,33 @@
 <?php
-include('../InvoicePrinter.php');
+
+include '../InvoicePrinter.php';
 $invoice = new InvoicePrinter();
   /* Header Settings */
-  $invoice->setLogo("images/sample1.jpg");
-  $invoice->setColor("#007fff");
-  $invoice->setType("Sale Invoice");
-  $invoice->setReference("INV-55033645");
-  $invoice->setDate(date('M dS ,Y',time()));
-  $invoice->setTime(date('h:i:s A',time()));
-  $invoice->setDue(date('M dS ,Y',strtotime('+3 months')));
-  $invoice->setFrom(array("Seller Name","Sample Company Name","128 AA Juanita Ave","Glendora , CA 91740","United States of America"));
-  $invoice->setTo(array("Purchaser Name","Sample Company Name","128 AA Juanita Ave","Glendora , CA 91740","United States of America"));
+  $invoice->setLogo('images/sample1.jpg');
+  $invoice->setColor('#007fff');
+  $invoice->setType('Sale Invoice');
+  $invoice->setReference('INV-55033645');
+  $invoice->setDate(date('M dS ,Y', time()));
+  $invoice->setTime(date('h:i:s A', time()));
+  $invoice->setDue(date('M dS ,Y', strtotime('+3 months')));
+  $invoice->setFrom(['Seller Name', 'Sample Company Name', '128 AA Juanita Ave', 'Glendora , CA 91740', 'United States of America']);
+  $invoice->setTo(['Purchaser Name', 'Sample Company Name', '128 AA Juanita Ave', 'Glendora , CA 91740', 'United States of America']);
   /* Adding Items in table */
-  $invoice->addItem("AMD Athlon X2DC-7450","2.4GHz/1GB/160GB/SMP-DVD/VB",6,0,580,0,3480);
-  $invoice->addItem("PDC-E5300","2.6GHz/1GB/320GB/SMP-DVD/FDD/VB",4,0,645,0,2580);
-  $invoice->addItem('LG 18.5" WLCD',"",10,0,230,0,2300);
-  $invoice->addItem("HP LaserJet 5200","",1,0,1100,0,1100);
+  $invoice->addItem('AMD Athlon X2DC-7450', '2.4GHz/1GB/160GB/SMP-DVD/VB', 6, 0, 580, 0, 3480);
+  $invoice->addItem('PDC-E5300', '2.6GHz/1GB/320GB/SMP-DVD/FDD/VB', 4, 0, 645, 0, 2580);
+  $invoice->addItem('LG 18.5" WLCD', '', 10, 0, 230, 0, 2300);
+  $invoice->addItem('HP LaserJet 5200', '', 1, 0, 1100, 0, 1100);
   /* Add totals */
-  $invoice->addTotal("Total",9460);
-  $invoice->addTotal("VAT 21%",1986.6);
-  $invoice->addTotal("Total due",11446.6,true);
-  /* Set badge */ 
-  $invoice->addBadge("Payment Paid");
+  $invoice->addTotal('Total', 9460);
+  $invoice->addTotal('VAT 21%', 1986.6);
+  $invoice->addTotal('Total due', 11446.6, true);
+  /* Set badge */
+  $invoice->addBadge('Payment Paid');
   /* Add title */
-  $invoice->addTitle("Important Notice");
+  $invoice->addTitle('Important Notice');
   /* Add Paragraph */
   $invoice->addParagraph("No item will be replaced or refunded if you don't have the invoice with you. You can refund within 2 days of purchase.");
   /* Set footer note */
-  $invoice->setFooternote("My Company Name Here");
+  $invoice->setFooternote('My Company Name Here');
   /* Render */
-  $invoice->render('example1.pdf','I'); /* I => Display on browser, D => Force Download, F => local path save, S => return document path */
-?>
+  $invoice->render('example1.pdf', 'I'); /* I => Display on browser, D => Force Download, F => local path save, S => return document path */

--- a/examples/example2.php
+++ b/examples/example2.php
@@ -1,32 +1,32 @@
 <?php
-include('../InvoicePrinter.php');
+
+include '../InvoicePrinter.php';
 $invoice = new InvoicePrinter();
   /* Header Settings */
-  $invoice->setLogo("images/example3.jpg");
-  $invoice->setColor("#AA3939");
-  $invoice->setType("Sale Invoice");
-  $invoice->setReference("INV-55033645");
-  $invoice->setDate(date('M dS ,Y',time()));
-  $invoice->setDue(date('M dS ,Y',strtotime('+3 months')));
-  $invoice->setFrom(array("Seller Name","Sample Company Name","128 AA Juanita Ave","Glendora , CA 91740","United States of America"));
-  $invoice->setTo(array("Purchaser Name","Sample Company Name","128 AA Juanita Ave","Glendora , CA 91740","United States of America"));
+  $invoice->setLogo('images/example3.jpg');
+  $invoice->setColor('#AA3939');
+  $invoice->setType('Sale Invoice');
+  $invoice->setReference('INV-55033645');
+  $invoice->setDate(date('M dS ,Y', time()));
+  $invoice->setDue(date('M dS ,Y', strtotime('+3 months')));
+  $invoice->setFrom(['Seller Name', 'Sample Company Name', '128 AA Juanita Ave', 'Glendora , CA 91740', 'United States of America']);
+  $invoice->setTo(['Purchaser Name', 'Sample Company Name', '128 AA Juanita Ave', 'Glendora , CA 91740', 'United States of America']);
   /* Adding Items in table */
-  $invoice->addItem("AMD Athlon X2DC-7450","2.4GHz/1GB/160GB/SMP-DVD/VB",6,0,580,0,3480);
-  $invoice->addItem("PDC-E5300","2.6GHz/1GB/320GB/SMP-DVD/FDD/VB",4,0,645,0,2580);
-  $invoice->addItem('LG 18.5" WLCD',"",10,0,230,0,2300);
-  $invoice->addItem("HP LaserJet 5200","",1,0,1100,0,1100);
+  $invoice->addItem('AMD Athlon X2DC-7450', '2.4GHz/1GB/160GB/SMP-DVD/VB', 6, 0, 580, 0, 3480);
+  $invoice->addItem('PDC-E5300', '2.6GHz/1GB/320GB/SMP-DVD/FDD/VB', 4, 0, 645, 0, 2580);
+  $invoice->addItem('LG 18.5" WLCD', '', 10, 0, 230, 0, 2300);
+  $invoice->addItem('HP LaserJet 5200', '', 1, 0, 1100, 0, 1100);
   /* Add totals */
-  $invoice->addTotal("Total",9460);
-  $invoice->addTotal("VAT 21%",1986.6);
-  $invoice->addTotal("Total due",11446.6,true);
-  /* Set badge */ 
-  $invoice->addBadge("Invoice Copy");
+  $invoice->addTotal('Total', 9460);
+  $invoice->addTotal('VAT 21%', 1986.6);
+  $invoice->addTotal('Total due', 11446.6, true);
+  /* Set badge */
+  $invoice->addBadge('Invoice Copy');
   /* Add title */
-  $invoice->addTitle("Important Notice");
+  $invoice->addTitle('Important Notice');
   /* Add Paragraph */
   $invoice->addParagraph("No item will be replaced or refunded if you don't have the invoice with you. You can refund within 2 days of purchase.");
   /* Set footer note */
-  $invoice->setFooternote("My Company Name Here");
+  $invoice->setFooternote('My Company Name Here');
   /* Render */
-  $invoice->render('example2.pdf','D'); /* I => Display on browser, D => Force Download, F => local path save, S => return document path */
-?>
+  $invoice->render('example2.pdf', 'D'); /* I => Display on browser, D => Force Download, F => local path save, S => return document path */

--- a/examples/simple.php
+++ b/examples/simple.php
@@ -1,22 +1,22 @@
 <?php
-include('../InvoicePrinter.php');
+
+include '../InvoicePrinter.php';
 $invoice = new InvoicePrinter();
   /* Header Settings */
-  $invoice->setLogo("images/simple_sample.png");
-  $invoice->setColor("#677a1a");
-  $invoice->setType("Simple Invoice");
-  $invoice->setReference("55033645");
-  $invoice->setDate(date('d-m-Y',time()));
-  $invoice->setDue(date('d-m-Y',strtotime('+3 months')));
+  $invoice->setLogo('images/simple_sample.png');
+  $invoice->setColor('#677a1a');
+  $invoice->setType('Simple Invoice');
+  $invoice->setReference('55033645');
+  $invoice->setDate(date('d-m-Y', time()));
+  $invoice->setDue(date('d-m-Y', strtotime('+3 months')));
   $invoice->hide_tofrom();
   /* Adding Items in table */
-  $invoice->addItem("AMD Athlon X2DC-7450","2.4GHz/1GB/160GB/SMP-DVD/VB",6,false,580,false,3480);
-  $invoice->addItem("PDC-E5300","2.6GHz/1GB/320GB/SMP-DVD/FDD/VB",4,false,645,false,2580);
-  $invoice->addItem('LG 18.5" WLCD',"",10,false,230,false,2300);
-  $invoice->addItem("HP LaserJet 5200","",1,false,1100,false,1100);
+  $invoice->addItem('AMD Athlon X2DC-7450', '2.4GHz/1GB/160GB/SMP-DVD/VB', 6, false, 580, false, 3480);
+  $invoice->addItem('PDC-E5300', '2.6GHz/1GB/320GB/SMP-DVD/FDD/VB', 4, false, 645, false, 2580);
+  $invoice->addItem('LG 18.5" WLCD', '', 10, false, 230, false, 2300);
+  $invoice->addItem('HP LaserJet 5200', '', 1, false, 1100, false, 1100);
   /* Add totals */
-  $invoice->addTotal("Total",9460);
-  $invoice->addTotal("Total due",9460,true);
+  $invoice->addTotal('Total', 9460);
+  $invoice->addTotal('Total due', 9460, true);
   /* Render */
-  $invoice->render('example2.pdf','I'); /* I => Display on browser, D => Force Download, F => local path save, S => return document path */
-?>
+  $invoice->render('example2.pdf', 'I'); /* I => Display on browser, D => Force Download, F => local path save, S => return document path */

--- a/inc/languages/nl.inc
+++ b/inc/languages/nl.inc
@@ -3,7 +3,7 @@
     $lang['date']     = 'Aangemaakt';
     $lang['time']     = 'Tijd';
     $lang['due']      = 'Vervaldatum';
-    $lang['to']       = 'Begunstige';
+    $lang['to']       = 'Begunstigde';
     $lang['from']     = 'Onze gegevens';
     $lang['product']  = 'Product';
     $lang['qty']      = 'Aantal';

--- a/inc/languages/nl.inc
+++ b/inc/languages/nl.inc
@@ -12,4 +12,4 @@
     $lang['vat']      = 'BTW';
     $lang['total']    = 'Totaal';
     $lang['page']     = 'Pagina';
-    $lang['page_of']  = 'van de';
+    $lang['page_of']  = 'van';

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -19,17 +19,17 @@ class InvoicePrinter extends FPDF
     const ICONV_CHARSET_OUTPUT_A = 'ISO-8859-1//TRANSLIT';
     const ICONV_CHARSET_OUTPUT_B = 'windows-1252//TRANSLIT';
 
-    public $angle           = 0;
-    public $font            = 'helvetica';        /* Font Name : See inc/fpdf/font for all supported fonts */
-    public $columnOpacity   = 0.06;            /* Items table background color opacity. Range (0.00 - 1) */
-    public $columnSpacing   = 0.3;                /* Spacing between Item Tables */
+    public $angle = 0;
+    public $font = 'helvetica';                 /* Font Name : See inc/fpdf/font for all supported fonts */
+    public $columnOpacity = 0.06;               /* Items table background color opacity. Range (0.00 - 1) */
+    public $columnSpacing = 0.3;                /* Spacing between Item Tables */
     public $referenceformat = ['.', ',', 'left', false];    /* Currency formater */
-    public $margins         = [
+    public $margins = [
         'l' => 15,
         't' => 15,
         'r' => 15
     ]; /* l: Left Side , t: Top Side , r: Right Side */
-    public $fontSizeProductDescription   = 7;                /* font size of product description */
+    public $fontSizeProductDescription = 7;                /* font size of product description */
 
     public $lang;
     public $document;
@@ -55,11 +55,11 @@ class InvoicePrinter extends FPDF
 
     public function __construct($size = 'A4', $currency = '$', $language = 'en')
     {
-        $this->items              = [];
-        $this->totals             = [];
-        $this->addText            = [];
-        $this->firstColumnWidth   = 70;
-        $this->currency           = $currency;
+        $this->items = [];
+        $this->totals = [];
+        $this->addText = [];
+        $this->firstColumnWidth = 70;
+        $this->currency = $currency;
         $this->maxImageDimensions = [230, 130];
         $this->setLanguage($language);
         $this->setDocumentSize($size);
@@ -107,9 +107,9 @@ class InvoicePrinter extends FPDF
     private function resizeToFit($image)
     {
         list($width, $height) = getimagesize($image);
-        $newWidth  = $this->maxImageDimensions[0] / $width;
+        $newWidth = $this->maxImageDimensions[0] / $width;
         $newHeight = $this->maxImageDimensions[1] / $height;
-        $scale     = min($newWidth, $newHeight);
+        $scale = min($newWidth, $newHeight);
 
         return [
             round($this->pixelsToMM($scale * $width)),
@@ -120,7 +120,7 @@ class InvoicePrinter extends FPDF
     private function pixelsToMM($val)
     {
         $mm_inch = 25.4;
-        $dpi     = 96;
+        $dpi = 96;
 
         return ($val * $mm_inch) / $dpi;
     }
@@ -195,7 +195,7 @@ class InvoicePrinter extends FPDF
         if ($maxWidth and $maxHeight) {
             $this->maxImageDimensions = [$maxWidth, $maxHeight];
         }
-        $this->logo       = $logo;
+        $this->logo = $logo;
         $this->dimensions = $this->resizeToFit($logo);
     }
 
@@ -204,7 +204,7 @@ class InvoicePrinter extends FPDF
         $this->display_tofrom = false;
     }
 
-	public function hideToFromHeaders()
+    public function hideToFromHeaders()
     {
         $this->displayToFromHeaders = false;
     }
@@ -244,7 +244,7 @@ class InvoicePrinter extends FPDF
         $decimalPoint = $this->referenceformat[0];
         $thousandSeparator = $this->referenceformat[1];
         $alignment = isset($this->referenceformat[2]) ? strtolower($this->referenceformat[2]) : 'left';
-        $spaceBetweenCurrencyAndAmount = isset($this->referenceformat[3]) ? (bool) $this->referenceformat[3] : true;
+        $spaceBetweenCurrencyAndAmount = isset($this->referenceformat[3]) ? (bool)$this->referenceformat[3] : true;
         $space = $spaceBetweenCurrencyAndAmount ? ' ' : '';
 
         if ('right' == $alignment) {
@@ -256,7 +256,7 @@ class InvoicePrinter extends FPDF
 
     public function addItem($item, $description = "", $quantity, $vat, $price, $discount = 0, $total)
     {
-        $p['item']        = $item;
+        $p['item'] = $item;
         $p['description'] = $this->br2nl($description);
 
         if ($vat !== false) {
@@ -268,12 +268,12 @@ class InvoicePrinter extends FPDF
             $this->recalculateColumns();
         }
         $p['quantity'] = $quantity;
-        $p['price']    = $price;
-        $p['total']    = $total;
+        $p['price'] = $price;
+        $p['total'] = $total;
 
         if ($discount !== false) {
             $this->firstColumnWidth = 58;
-            $p['discount']          = $discount;
+            $p['discount'] = $discount;
             if (is_numeric($discount)) {
                 $p['discount'] = $this->price($discount);
             }
@@ -285,12 +285,12 @@ class InvoicePrinter extends FPDF
 
     public function addTotal($name, $value, $colored = false)
     {
-        $t['name']  = $name;
+        $t['name'] = $name;
         $t['value'] = $value;
         if (is_numeric($value)) {
             $t['value'] = $this->price($value);
         }
-        $t['colored']   = $colored;
+        $t['colored'] = $colored;
         $this->totals[] = $t;
     }
 
@@ -301,7 +301,7 @@ class InvoicePrinter extends FPDF
 
     public function addParagraph($paragraph)
     {
-        $paragraph       = $this->br2nl($paragraph);
+        $paragraph = $this->br2nl($paragraph);
         $this->addText[] = ['paragraph', $paragraph];
     }
 
@@ -339,7 +339,7 @@ class InvoicePrinter extends FPDF
         //Title
         $this->SetTextColor(0, 0, 0);
         $this->SetFont($this->font, 'B', 20);
-        if(isset($this->title) and !empty($this->title)) {
+        if (isset($this->title) and !empty($this->title)) {
             $this->Cell(0, 5, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->title, self::ICONV_CHARSET_INPUT)), 0, 1, 'R');
         }
         $this->SetFont($this->font, '', 9);
@@ -408,14 +408,14 @@ class InvoicePrinter extends FPDF
             $this->SetFont($this->font, 'B', 10);
             $width = ($this->document['w'] - $this->margins['l'] - $this->margins['r']) / 2;
             if (isset($this->flipflop)) {
-                $to                 = $this->lang['to'];
-                $from               = $this->lang['from'];
-                $this->lang['to']   = $from;
+                $to = $this->lang['to'];
+                $from = $this->lang['from'];
+                $this->lang['to'] = $from;
                 $this->lang['from'] = $to;
-                $to                 = $this->to;
-                $from               = $this->from;
-                $this->to           = $from;
-                $this->from         = $to;
+                $to = $this->to;
+                $from = $this->from;
+                $this->to = $from;
+                $this->from = $to;
             }
 
             if ($this->display_tofrom === true) {
@@ -492,11 +492,11 @@ class InvoicePrinter extends FPDF
     public function Body()
     {
         $width_other = ($this->document['w'] - $this->margins['l'] - $this->margins['r'] - $this->firstColumnWidth - ($this->columns * $this->columnSpacing)) / ($this->columns - 1);
-        $cellHeight  = 8;
-        $bgcolor     = (1 - $this->columnOpacity) * 255;
+        $cellHeight = 8;
+        $bgcolor = (1 - $this->columnOpacity) * 255;
         if ($this->items) {
             foreach ($this->items as $item) {
-                if ( (empty($item['item'])) || (empty($item['description'])))  {
+                if ((empty($item['item'])) || (empty($item['description']))) {
                     $this->Ln($this->columnSpacing);
                 }
                 if ($item['description']) {
@@ -508,7 +508,7 @@ class InvoicePrinter extends FPDF
                     $calculateHeight->MultiCell($this->firstColumnWidth, 3,
                         iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, $item['description']), 0, 'L', 1);
                     $descriptionHeight = $calculateHeight->getY() + $cellHeight + 2;
-                    $pageHeight        = $this->document['h'] - $this->GetY() - $this->margins['t'] - $this->margins['t'];
+                    $pageHeight = $this->document['h'] - $this->GetY() - $this->margins['t'] - $this->margins['t'];
                     if ($pageHeight < 35) {
                         $this->AddPage();
                     }
@@ -527,10 +527,10 @@ class InvoicePrinter extends FPDF
                     $this->SetTextColor(120, 120, 120);
                     $this->SetXY($x, $this->GetY() + 8);
                     $this->SetFont($this->font, '', $this->fontSizeProductDescription);
-                    $this->MultiCell($this->firstColumnWidth, floor($this->fontSizeProductDescription/2), iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, $item['description']), 0,
+                    $this->MultiCell($this->firstColumnWidth, floor($this->fontSizeProductDescription / 2), iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, $item['description']), 0,
                         'L', 1);
                     //Calculate Height
-                    $newY    = $this->GetY();
+                    $newY = $this->GetY();
                     $cHeight = $newY - $resetY + 2;
                     //Make our spacer cell the same height
                     $this->SetXY($x - 1, $resetY);
@@ -613,7 +613,7 @@ class InvoicePrinter extends FPDF
 
         //Badge
         if ($this->badge) {
-            $badge  = ' ' . mb_strtoupper($this->badge, self::ICONV_CHARSET_INPUT) . ' ';
+            $badge = ' ' . mb_strtoupper($this->badge, self::ICONV_CHARSET_INPUT) . ' ';
             $resetX = $this->getX();
             $resetY = $this->getY();
             $this->setXY($badgeX, $badgeY + 15);
@@ -623,7 +623,7 @@ class InvoicePrinter extends FPDF
             $this->SetFont($this->font, 'b', 15);
             $this->Rotate(10, $this->getX(), $this->getY());
             $this->Rect($this->GetX(), $this->GetY(), $this->GetStringWidth($badge) + 2, 10);
-            $this->Write(10,  iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_B,mb_strtoupper($badge, self::ICONV_CHARSET_INPUT)));
+            $this->Write(10, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_B, mb_strtoupper($badge, self::ICONV_CHARSET_INPUT)));
             $this->Rotate(0);
             if ($resetY > $this->getY() + 20) {
                 $this->setXY($resetX, $resetY);
@@ -678,10 +678,10 @@ class InvoicePrinter extends FPDF
         $this->angle = $angle;
         if ($angle != 0) {
             $angle *= M_PI / 180;
-            $c     = cos($angle);
-            $s     = sin($angle);
-            $cx    = $x * $this->k;
-            $cy    = ($this->h - $y) * $this->k;
+            $c = cos($angle);
+            $s = sin($angle);
+            $cx = $x * $this->k;
+            $cy = ($this->h - $y) * $this->k;
             $this->_out(sprintf('q %.5F %.5F %.5F %.5F %.2F %.2F cm 1 0 0 1 %.2F %.2F cm', $c, $s, -$s, $c, $cx, $cy,
                 -$cx, -$cy));
         }

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -226,9 +226,9 @@ class InvoicePrinter extends FPDF
         $this->reference = $reference;
     }
 
-    public function setNumberFormat($decimals, $thousands_sep)
+    public function setNumberFormat($decimals = '.', $thousands_sep = ',', $alignment = 'left', $space = true)
     {
-        $this->referenceformat = [$decimals, $thousands_sep];
+        $this->referenceformat = [$decimals, $thousands_sep, $alignment, $space];
     }
 
     public function setFontSizeProductDescription($data)

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -441,12 +441,12 @@ class InvoicePrinter extends FPDF
                 $this->SetTextColor(100, 100, 100);
                 $this->Ln(7);
                 for ($i = 1, $iMax = max($this->from === null ? 0 : count($this->from), $this->to === null ? 0 : count($this->to)); $i < $iMax; $i++) {
-                    // check if the TO or FROM array value is not empty.
-                    if($this->to[$i] !== ""){
-                        $this->Cell($width, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, $this->from[$i]), 0, 0, 'L');
-                        $this->Cell(0, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, $this->to[$i]), 0, 0, 'L');
-                        $this->Ln(5);
+                    // avoid undefined error if TO and FROM array lengths are different
+                    if (!empty($this->from[$i]) || !empty($this->to[$i])) {
+                        $this->Cell($width, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, empty($this->from[$i]) ? '' : $this->from[$i]), 0, 0, 'L');
+                        $this->Cell(0, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, empty($this->to[$i]) ? '' : $this->to[$i]), 0, 0, 'L');
                     }
+                    $this->Ln(5);
                 }
                 $this->Ln(-6);
                 $this->Ln(5);

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -78,7 +78,7 @@ class InvoicePrinter extends FPDF
     private function setLanguage($language)
     {
         $this->language = $language;
-        include dirname(__DIR__).'/inc/languages/'.$language.'.inc';
+        include dirname(__DIR__) . '/inc/languages/' . $language . '.inc';
         $this->lang = $lang;
     }
 
@@ -131,9 +131,9 @@ class InvoicePrinter extends FPDF
     {
         $hex = str_replace('#', '', $hex);
         if (strlen($hex) == 3) {
-            $r = hexdec(substr($hex, 0, 1).substr($hex, 0, 1));
-            $g = hexdec(substr($hex, 1, 1).substr($hex, 1, 1));
-            $b = hexdec(substr($hex, 2, 1).substr($hex, 2, 1));
+            $r = hexdec(substr($hex, 0, 1) . substr($hex, 0, 1));
+            $g = hexdec(substr($hex, 1, 1) . substr($hex, 1, 1));
+            $b = hexdec(substr($hex, 2, 1) . substr($hex, 2, 1));
         } else {
             $r = hexdec(substr($hex, 0, 2));
             $g = hexdec(substr($hex, 2, 2));
@@ -246,13 +246,13 @@ class InvoicePrinter extends FPDF
         $decimalPoint = $this->referenceformat[0];
         $thousandSeparator = $this->referenceformat[1];
         $alignment = isset($this->referenceformat[2]) ? strtolower($this->referenceformat[2]) : 'left';
-        $spaceBetweenCurrencyAndAmount = isset($this->referenceformat[3]) ? (bool) $this->referenceformat[3] : true;
+        $spaceBetweenCurrencyAndAmount = isset($this->referenceformat[3]) ? (bool)$this->referenceformat[3] : true;
         $space = $spaceBetweenCurrencyAndAmount ? ' ' : '';
 
         if ('right' == $alignment) {
-            return number_format($price, 2, $decimalPoint, $thousandSeparator).$space.$this->currency;
+            return number_format($price, 2, $decimalPoint, $thousandSeparator) . $space . $this->currency;
         } else {
-            return $this->currency.$space.number_format($price, 2, $decimalPoint, $thousandSeparator);
+            return $this->currency . $space . number_format($price, 2, $decimalPoint, $thousandSeparator);
         }
     }
 
@@ -351,9 +351,12 @@ class InvoicePrinter extends FPDF
         $lineheight = 5;
         //Calculate position of strings
         $this->SetFont($this->font, 'B', 9);
-        $positionX = $this->document['w'] - $this->margins['l'] - $this->margins['r'] - max(mb_strtoupper($this->GetStringWidth($this->lang['number'], self::ICONV_CHARSET_INPUT)),
-                mb_strtoupper($this->GetStringWidth($this->lang['date'], self::ICONV_CHARSET_INPUT)),
-                mb_strtoupper($this->GetStringWidth($this->lang['due'], self::ICONV_CHARSET_INPUT))) - 35;
+        $positionX = $this->document['w'] - $this->margins['l'] - $this->margins['r']
+            - max($this->GetStringWidth(mb_strtoupper($this->lang['number'], self::ICONV_CHARSET_INPUT)),
+                $this->GetStringWidth(mb_strtoupper($this->lang['date'], self::ICONV_CHARSET_INPUT)),
+                $this->GetStringWidth(mb_strtoupper($this->lang['due'], self::ICONV_CHARSET_INPUT)))
+            - max($this->GetStringWidth(mb_strtoupper($this->reference, self::ICONV_CHARSET_INPUT)),
+                $this->GetStringWidth(mb_strtoupper($this->date, self::ICONV_CHARSET_INPUT)));
 
         //Number
         if (!empty($this->reference)) {
@@ -614,7 +617,7 @@ class InvoicePrinter extends FPDF
 
         //Badge
         if ($this->badge) {
-            $badge = ' '.mb_strtoupper($this->badge, self::ICONV_CHARSET_INPUT).' ';
+            $badge = ' ' . mb_strtoupper($this->badge, self::ICONV_CHARSET_INPUT) . ' ';
             $resetX = $this->getX();
             $resetY = $this->getY();
             $this->setXY($badgeX, $badgeY + 15);

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -3,10 +3,12 @@
  * Contains the InvoicePrinter class.
  *
  * @author      Farjad Tahir
- * @see         http://www.splashpk.com
- * @license     GPL
- * @since       2017-12-15
  *
+ * @see         http://www.splashpk.com
+ *
+ * @license     GPL
+ *
+ * @since       2017-12-15
  */
 
 namespace Konekt\PdfInvoice;
@@ -27,7 +29,7 @@ class InvoicePrinter extends FPDF
     public $margins = [
         'l' => 15,
         't' => 15,
-        'r' => 15
+        'r' => 15,
     ]; /* l: Left Side , t: Top Side , r: Right Side */
     public $fontSizeProductDescription = 7;                /* font size of product description */
 
@@ -63,7 +65,7 @@ class InvoicePrinter extends FPDF
         $this->maxImageDimensions = [230, 130];
         $this->setLanguage($language);
         $this->setDocumentSize($size);
-        $this->setColor("#222222");
+        $this->setColor('#222222');
 
         $this->recalculateColumns();
 
@@ -76,7 +78,7 @@ class InvoicePrinter extends FPDF
     private function setLanguage($language)
     {
         $this->language = $language;
-        include(dirname(__DIR__) . '/inc/languages/' . $language . '.inc');
+        include dirname(__DIR__).'/inc/languages/'.$language.'.inc';
         $this->lang = $lang;
     }
 
@@ -113,7 +115,7 @@ class InvoicePrinter extends FPDF
 
         return [
             round($this->pixelsToMM($scale * $width)),
-            round($this->pixelsToMM($scale * $height))
+            round($this->pixelsToMM($scale * $height)),
         ];
     }
 
@@ -127,11 +129,11 @@ class InvoicePrinter extends FPDF
 
     private function hex2rgb($hex)
     {
-        $hex = str_replace("#", "", $hex);
+        $hex = str_replace('#', '', $hex);
         if (strlen($hex) == 3) {
-            $r = hexdec(substr($hex, 0, 1) . substr($hex, 0, 1));
-            $g = hexdec(substr($hex, 1, 1) . substr($hex, 1, 1));
-            $b = hexdec(substr($hex, 2, 1) . substr($hex, 2, 1));
+            $r = hexdec(substr($hex, 0, 1).substr($hex, 0, 1));
+            $g = hexdec(substr($hex, 1, 1).substr($hex, 1, 1));
+            $b = hexdec(substr($hex, 2, 1).substr($hex, 2, 1));
         } else {
             $r = hexdec(substr($hex, 0, 2));
             $g = hexdec(substr($hex, 2, 2));
@@ -158,7 +160,7 @@ class InvoicePrinter extends FPDF
         return true;
     }
 
-    public function setTimeZone($zone = "")
+    public function setTimeZone($zone = '')
     {
         if (!empty($zone) and $this->isValidTimezoneId($zone) === true) {
             date_default_timezone_set($zone);
@@ -244,17 +246,17 @@ class InvoicePrinter extends FPDF
         $decimalPoint = $this->referenceformat[0];
         $thousandSeparator = $this->referenceformat[1];
         $alignment = isset($this->referenceformat[2]) ? strtolower($this->referenceformat[2]) : 'left';
-        $spaceBetweenCurrencyAndAmount = isset($this->referenceformat[3]) ? (bool)$this->referenceformat[3] : true;
+        $spaceBetweenCurrencyAndAmount = isset($this->referenceformat[3]) ? (bool) $this->referenceformat[3] : true;
         $space = $spaceBetweenCurrencyAndAmount ? ' ' : '';
 
         if ('right' == $alignment) {
-            return number_format($price, 2, $decimalPoint, $thousandSeparator) . $space . $this->currency;
+            return number_format($price, 2, $decimalPoint, $thousandSeparator).$space.$this->currency;
         } else {
-            return $this->currency . $space . number_format($price, 2, $decimalPoint, $thousandSeparator);
+            return $this->currency.$space.number_format($price, 2, $decimalPoint, $thousandSeparator);
         }
     }
 
-    public function addItem($item, $description = "", $quantity, $vat, $price, $discount = 0, $total)
+    public function addItem($item, $description, $quantity, $vat, $price, $discount, $total)
     {
         $p['item'] = $item;
         $p['description'] = $this->br2nl($description);
@@ -326,6 +328,7 @@ class InvoicePrinter extends FPDF
         $this->AddPage();
         $this->Body();
         $this->AliasNbPages();
+
         return $this->Output($destination, $name);
     }
 
@@ -356,7 +359,7 @@ class InvoicePrinter extends FPDF
         if (!empty($this->reference)) {
             $this->Cell($positionX, $lineheight);
             $this->SetTextColor($this->color[0], $this->color[1], $this->color[2]);
-            $this->Cell(32, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['number'], self::ICONV_CHARSET_INPUT) . ':'), 0, 0,
+            $this->Cell(32, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['number'], self::ICONV_CHARSET_INPUT).':'), 0, 0,
                 'L');
             $this->SetTextColor(50, 50, 50);
             $this->SetFont($this->font, '', 9);
@@ -366,7 +369,7 @@ class InvoicePrinter extends FPDF
         $this->Cell($positionX, $lineheight);
         $this->SetFont($this->font, 'B', 9);
         $this->SetTextColor($this->color[0], $this->color[1], $this->color[2]);
-        $this->Cell(32, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['date'], self::ICONV_CHARSET_INPUT)) . ':', 0, 0, 'L');
+        $this->Cell(32, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['date'], self::ICONV_CHARSET_INPUT)).':', 0, 0, 'L');
         $this->SetTextColor(50, 50, 50);
         $this->SetFont($this->font, '', 9);
         $this->Cell(0, $lineheight, $this->date, 0, 1, 'R');
@@ -376,7 +379,7 @@ class InvoicePrinter extends FPDF
             $this->Cell($positionX, $lineheight);
             $this->SetFont($this->font, 'B', 9);
             $this->SetTextColor($this->color[0], $this->color[1], $this->color[2]);
-            $this->Cell(32, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['time'], self::ICONV_CHARSET_INPUT)) . ':', 0, 0,
+            $this->Cell(32, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['time'], self::ICONV_CHARSET_INPUT)).':', 0, 0,
                 'L');
             $this->SetTextColor(50, 50, 50);
             $this->SetFont($this->font, '', 9);
@@ -387,7 +390,7 @@ class InvoicePrinter extends FPDF
             $this->Cell($positionX, $lineheight);
             $this->SetFont($this->font, 'B', 9);
             $this->SetTextColor($this->color[0], $this->color[1], $this->color[2]);
-            $this->Cell(32, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['due'], self::ICONV_CHARSET_INPUT)) . ':', 0, 0, 'L');
+            $this->Cell(32, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['due'], self::ICONV_CHARSET_INPUT)).':', 0, 0, 'L');
             $this->SetTextColor(50, 50, 50);
             $this->SetFont($this->font, '', 9);
             $this->Cell(0, $lineheight, $this->due, 0, 1, 'R');
@@ -501,7 +504,7 @@ class InvoicePrinter extends FPDF
                 }
                 if ($item['description']) {
                     //Precalculate height
-                    $calculateHeight = new self;
+                    $calculateHeight = new self();
                     $calculateHeight->addPage();
                     $calculateHeight->setXY(0, 0);
                     $calculateHeight->SetFont($this->font, '', 7);
@@ -551,7 +554,6 @@ class InvoicePrinter extends FPDF
                     } else {
                         $this->Cell($width_other, $cHeight, '', 0, 0, 'C', 1);
                     }
-
                 }
                 $this->Cell($this->columnSpacing, $cHeight, '', 0, 0, 'L', 0);
                 $this->Cell($width_other, $cHeight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_B,
@@ -610,10 +612,9 @@ class InvoicePrinter extends FPDF
         $this->Ln();
         $this->Ln(3);
 
-
         //Badge
         if ($this->badge) {
-            $badge = ' ' . mb_strtoupper($this->badge, self::ICONV_CHARSET_INPUT) . ' ';
+            $badge = ' '.mb_strtoupper($this->badge, self::ICONV_CHARSET_INPUT).' ';
             $resetX = $this->getX();
             $resetY = $this->getY();
             $this->setXY($badgeX, $badgeY + 15);
@@ -660,7 +661,7 @@ class InvoicePrinter extends FPDF
         $this->SetFont($this->font, '', 8);
         $this->SetTextColor(50, 50, 50);
         $this->Cell(0, 10, $this->footernote, 0, 0, 'L');
-        $this->Cell(0, 10, iconv('UTF-8', 'ISO-8859-1', $this->lang['page']) . ' ' . $this->PageNo() . ' ' . $this->lang['page_of'] . ' {nb}', 0, 0,
+        $this->Cell(0, 10, iconv('UTF-8', 'ISO-8859-1', $this->lang['page']).' '.$this->PageNo().' '.$this->lang['page_of'].' {nb}', 0, 0,
             'R');
     }
 
@@ -700,10 +701,12 @@ class InvoicePrinter extends FPDF
     {
         $this->columns = 4;
 
-        if (isset($this->vatField))
+        if (isset($this->vatField)) {
             $this->columns += 1;
+        }
 
-        if (isset($this->discountField))
+        if (isset($this->discountField)) {
             $this->columns += 1;
+        }
     }
 }

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -78,7 +78,7 @@ class InvoicePrinter extends FPDF
     private function setLanguage($language)
     {
         $this->language = $language;
-        include dirname(__DIR__) . '/inc/languages/' . $language . '.inc';
+        include dirname(__DIR__).'/inc/languages/'.$language.'.inc';
         $this->lang = $lang;
     }
 
@@ -131,9 +131,9 @@ class InvoicePrinter extends FPDF
     {
         $hex = str_replace('#', '', $hex);
         if (strlen($hex) == 3) {
-            $r = hexdec(substr($hex, 0, 1) . substr($hex, 0, 1));
-            $g = hexdec(substr($hex, 1, 1) . substr($hex, 1, 1));
-            $b = hexdec(substr($hex, 2, 1) . substr($hex, 2, 1));
+            $r = hexdec(substr($hex, 0, 1).substr($hex, 0, 1));
+            $g = hexdec(substr($hex, 1, 1).substr($hex, 1, 1));
+            $b = hexdec(substr($hex, 2, 1).substr($hex, 2, 1));
         } else {
             $r = hexdec(substr($hex, 0, 2));
             $g = hexdec(substr($hex, 2, 2));
@@ -246,13 +246,13 @@ class InvoicePrinter extends FPDF
         $decimalPoint = $this->referenceformat[0];
         $thousandSeparator = $this->referenceformat[1];
         $alignment = isset($this->referenceformat[2]) ? strtolower($this->referenceformat[2]) : 'left';
-        $spaceBetweenCurrencyAndAmount = isset($this->referenceformat[3]) ? (bool)$this->referenceformat[3] : true;
+        $spaceBetweenCurrencyAndAmount = isset($this->referenceformat[3]) ? (bool) $this->referenceformat[3] : true;
         $space = $spaceBetweenCurrencyAndAmount ? ' ' : '';
 
         if ('right' == $alignment) {
-            return number_format($price, 2, $decimalPoint, $thousandSeparator) . $space . $this->currency;
+            return number_format($price, 2, $decimalPoint, $thousandSeparator).$space.$this->currency;
         } else {
-            return $this->currency . $space . number_format($price, 2, $decimalPoint, $thousandSeparator);
+            return $this->currency.$space.number_format($price, 2, $decimalPoint, $thousandSeparator);
         }
     }
 
@@ -617,7 +617,7 @@ class InvoicePrinter extends FPDF
 
         //Badge
         if ($this->badge) {
-            $badge = ' ' . mb_strtoupper($this->badge, self::ICONV_CHARSET_INPUT) . ' ';
+            $badge = ' '.mb_strtoupper($this->badge, self::ICONV_CHARSET_INPUT).' ';
             $resetX = $this->getX();
             $resetY = $this->getY();
             $this->setXY($badgeX, $badgeY + 15);

--- a/tests/AAASmokeTest.php
+++ b/tests/AAASmokeTest.php
@@ -5,13 +5,11 @@
  * @copyright   Copyright (c) 2017 Attila Fulop
  * @author      Attila Fulop
  * @license     GPL
- * @since       2017-12-15
  *
+ * @since       2017-12-15
  */
 
-
 namespace Konekt\PdfInvoice\Tests;
-
 
 use PHPUnit\Framework\TestCase;
 
@@ -20,7 +18,7 @@ class AAASmokeTest extends TestCase
     const MIN_PHP_VERSION = '5.6.0';
 
     /**
-     * Very Basic smoke test case for testing against parse errors, etc
+     * Very Basic smoke test case for testing against parse errors, etc.
      *
      * @test
      */
@@ -28,5 +26,4 @@ class AAASmokeTest extends TestCase
     {
         $this->assertTrue(true);
     }
-
 }

--- a/tests/BaseClassTest.php
+++ b/tests/BaseClassTest.php
@@ -5,13 +5,11 @@
  * @copyright   Copyright (c) 2017 Attila Fulop
  * @author      Attila Fulop
  * @license     GPL
- * @since       2017-12-15
  *
+ * @since       2017-12-15
  */
 
-
 namespace Konekt\PdfInvoice\Tests;
-
 
 use Konekt\PdfInvoice\InvoicePrinter;
 use PHPUnit\Framework\TestCase;
@@ -23,9 +21,8 @@ class BaseClassTest extends TestCase
      */
     public function can_be_instantiated()
     {
-        $invoicr =  new InvoicePrinter();
+        $invoicr = new InvoicePrinter();
 
         $this->assertInstanceOf(InvoicePrinter::class, $invoicr);
     }
-
 }


### PR DESCRIPTION
- avoid undefined offset exception when to and from array lengths are different.
- output only a line feed if the address line in both arrays is empty (intentional spacing)
- make sure the "reference" text will not overlap the reference itself (if very long)
- Dutch language corrections
- allow optional alignment and spacing settings to be set via setNumberFormat
- docs updated