### PR TITLE
Bugfix "Trying to access array offset on value of type null" by initialize from, to and dimensions in constructor.

### DIFF
--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -61,6 +61,9 @@ class InvoicePrinter extends FPDF
         $this->firstColumnWidth   = 70;
         $this->currency           = $currency;
         $this->maxImageDimensions = [230, 130];
+	  $this->dimensions         = [61.0, 34.0];
+        $this->from               = [''];
+        $this->to                 = [''];
         $this->setLanguage($language);
         $this->setDocumentSize($size);
         $this->setColor("#222222");


### PR DESCRIPTION
Hi,

This should avoid "Trying to access array offset on value of type null" when trying to calculate height for description on public function Body().

I think PR #31 is related in a different way.

This is a quick patch. We should think about a better way to resolve this.