### PR TITLE
Update $lang['total'] in German

### DIFF
--- a/inc/languages/de.inc
+++ b/inc/languages/de.inc
@@ -10,6 +10,6 @@
     $lang['price']    = 'Preis';
     $lang['discount'] = 'Rabatt';
     $lang['vat']      = 'MwSt';
-    $lang['total']    = 'Gesamtbetrag';
+    $lang['total']    = 'Gesamt';
     $lang['page']     = 'Seite';
     $lang['page_of']  = 'von';


### PR DESCRIPTION
Changed "Gesamtbetrag" to "Gesamt", because: 
- it is more commonly used as table-header
- usually "Gesamtbetrag" or "Rechnungsbetrag" go in the last "total-due" row
- currently "Gesamtbetrag" is a little too long, so it pushes a little over the table-head to the right, which isn't _that_ pretty