### PR TITLE
Allow to change a language term on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,15 @@ $invoice->addParagraph($paragraph);
 Paragraph {string} A string with the paragraph text with
 multi-line support. Use either <br> or \n to add a line-break.
 
+### Change a Language Term on the fly
+
+You can change a Language Term with this method. This overwrites the Term from the Language File.
+
+```php
+$invoice->changeLanguageTerm($term, $new);
+$invoice->changeLanguageTerm('date', 'Confirmation Date');
+```
+
 ### Footer
 
 A small text you want to display on the bottom left corner of the document.

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -52,6 +52,7 @@ class InvoicePrinter extends FPDF
     public $footernote;
     public $dimensions;
     public $display_tofrom = true;
+    public $customHeaders = [];
     protected $displayToFromHeaders = true;
     protected $columns;
 
@@ -264,6 +265,14 @@ class InvoicePrinter extends FPDF
         }
     }
 
+    public function addCustomHeader($title, $content)
+    {
+        $this->customHeaders[] = [
+            'title' => $title,
+            'content' => $content,
+        ];
+    }
+
     public function addItem($item, $description, $quantity, $vat, $price, $discount, $total)
     {
         $p['item'] = $item;
@@ -405,6 +414,18 @@ class InvoicePrinter extends FPDF
             $this->SetTextColor(50, 50, 50);
             $this->SetFont($this->font, '', 9);
             $this->Cell(0, $lineheight, $this->due, 0, 1, 'R');
+        }
+        //Custom Headers
+        if (count($this->customHeaders) > 0) {
+            foreach ($this->customHeaders as $customHeader) {
+                $this->Cell($positionX, $lineheight);
+                $this->SetFont($this->font, 'B', 9);
+                $this->SetTextColor($this->color[0], $this->color[1], $this->color[2]);
+                $this->Cell(32, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($customHeader['title'], self::ICONV_CHARSET_INPUT)) . ':', 0, 0, 'L');
+                $this->SetTextColor(50, 50, 50);
+                $this->SetFont($this->font, '', 9);
+                $this->Cell(0, $lineheight, $customHeader['content'], 0, 1, 'R');
+            }
         }
 
         //First page

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -152,6 +152,11 @@ class InvoicePrinter extends FPDF
         return preg_replace('/\<br(\s*)?\/?\>/i', "\n", $string);
     }
 
+    public function changeLanguageTerm($term, $new)
+    {
+        $this->lang[$term] = $new;
+    }
+
     public function isValidTimezoneId($zone)
     {
         try {


### PR DESCRIPTION
With the added method, the user can overwrite a term from the imported language file.

For Example:
In my app I will load the data from the database, so that my users can change the terms individually.