### PR TITLE
Use global namespace for DateTimeZone()

### DIFF
--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -161,7 +161,7 @@ class InvoicePrinter extends FPDF
     public function isValidTimezoneId($zone)
     {
         try {
-            new DateTimeZone($zone);
+            new \DateTimeZone($zone);
         } catch (Exception $e) {
             return false;
         }


### PR DESCRIPTION
Hi

I suggest to add \ to avoid this:
> Attempted to load class "DateTimeZone" from namespace "Konekt\PdfInvoice".
Did you forget a "use" statement for another namespace?