### PR TITLE
Optional price and total values

### DIFF
--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -546,45 +546,41 @@ class InvoicePrinter extends FPDF
             $this->Ln(12);
             $this->SetFont($this->font, 'B', 9);
             $this->Cell(1, 10, '', 0, 0, 'L', 0);
-            $this->Cell(
-                $this->firstColumnWidth,
-                10,
+            $this->Cell($this->firstColumnWidth, 10,
                 iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['product'], self::ICONV_CHARSET_INPUT)),
-                0,
-                0,
-                'L',
-                0
+                0, 0, 'L', 0
             );
             $this->Cell($this->columnSpacing, 10, '', 0, 0, 'L', 0);
             $this->Cell($width_other, 10, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['qty'], self::ICONV_CHARSET_INPUT)), 0, 0, 'C', 0);
             if (isset($this->vatField)) {
                 $this->Cell($this->columnSpacing, 10, '', 0, 0, 'L', 0);
-                $this->Cell(
-                    $width_other,
-                    10,
+                $this->Cell($width_other, 10,
                     iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['vat'], self::ICONV_CHARSET_INPUT)),
-                    0,
-                    0,
-                    'C',
-                    0
+                    0, 0, 'C', 0
                 );
             }
-            $this->Cell($this->columnSpacing, 10, '', 0, 0, 'L', 0);
-            $this->Cell($width_other, 10, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['price'], self::ICONV_CHARSET_INPUT)), 0, 0, 'C', 0);
+            if (isset($this->priceField)) {
+                $this->Cell($this->columnSpacing, 10, '', 0, 0, 'L', 0);
+                $this->Cell($width_other, 10,
+                    iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['price'], self::ICONV_CHARSET_INPUT)),
+                    0, 0,'C', 0
+                );
+            }
             if (isset($this->discountField)) {
                 $this->Cell($this->columnSpacing, 10, '', 0, 0, 'L', 0);
-                $this->Cell(
-                    $width_other,
-                    10,
+                $this->Cell($width_other, 10,
                     iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['discount'], self::ICONV_CHARSET_INPUT)),
-                    0,
-                    0,
-                    'C',
-                    0
+                    0, 0, 'C', 0
                 );
             }
-            $this->Cell($this->columnSpacing, 10, '', 0, 0, 'L', 0);
-            $this->Cell($width_other, 10, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['total'], self::ICONV_CHARSET_INPUT)), 0, 0, 'C', 0);
+            
+            if (isset($this->totalField)) {
+                $this->Cell($this->columnSpacing, 10, '', 0, 0, 'L', 0);
+                $this->Cell($width_other, 10,
+                    iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['total'], self::ICONV_CHARSET_INPUT)),
+                    0, 0,'C', 0
+                );
+            }
             $this->Ln();
             $this->SetLineWidth(0.3);
             $this->SetDrawColor($this->color[0], $this->color[1], $this->color[2]);
@@ -677,34 +673,30 @@ class InvoicePrinter extends FPDF
                         $this->Cell($width_other, $cHeight, '', 0, 0, 'C', 1);
                     }
                 }
-                $this->Cell($this->columnSpacing, $cHeight, '', 0, 0, 'L', 0);
-                $this->Cell($width_other, $cHeight, iconv(
-                    self::ICONV_CHARSET_INPUT,
-                    self::ICONV_CHARSET_OUTPUT_B,
-                    $this->price($item['price'])
-                ), 0, 0, 'C', 1);
-                if (isset($this->discountField)) {
+                if (isset($this->priceField)) {
                     $this->Cell($this->columnSpacing, $cHeight, '', 0, 0, 'L', 0);
-                    if (isset($item['discount'])) {
-                        $this->Cell(
-                            $width_other,
-                            $cHeight,
-                            iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_B, $item['discount']),
-                            0,
-                            0,
-                            'C',
-                            1
-                        );
+                    if (isset($item['price'])) {
+                        $this->Cell($width_other, $cHeight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_B, $item['price']), 0, 0, 'C', 1);
                     } else {
                         $this->Cell($width_other, $cHeight, '', 0, 0, 'C', 1);
                     }
                 }
-                $this->Cell($this->columnSpacing, $cHeight, '', 0, 0, 'L', 0);
-                $this->Cell($width_other, $cHeight, iconv(
-                    self::ICONV_CHARSET_INPUT,
-                    self::ICONV_CHARSET_OUTPUT_B,
-                    $this->price($item['total'])
-                ), 0, 0, 'C', 1);
+                if (isset($this->discountField)) {
+                    $this->Cell($this->columnSpacing, $cHeight, '', 0, 0, 'L', 0);
+                    if (isset($item['discount'])) {
+                        $this->Cell($width_other, $cHeight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_B, $item['discount']), 0, 0, 'C', 1);
+                    } else {
+                        $this->Cell($width_other, $cHeight, '', 0, 0, 'C', 1);
+                    }
+                }
+                if (isset($this->totalField)) {
+                    $this->Cell($this->columnSpacing, $cHeight, '', 0, 0, 'L', 0);
+                    if (isset($item['total'])) {
+                        $this->Cell($width_other, $cHeight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_B, $item['total']), 0, 0, 'C', 1);
+                    } else {
+                        $this->Cell($width_other, $cHeight, '', 0, 0, 'C', 1);
+                    }
+                }
                 $this->Ln();
                 $this->Ln($this->columnSpacing);
             }

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -546,39 +546,64 @@ class InvoicePrinter extends FPDF
             $this->Ln(12);
             $this->SetFont($this->font, 'B', 9);
             $this->Cell(1, 10, '', 0, 0, 'L', 0);
-            $this->Cell($this->firstColumnWidth, 10,
+            $this->Cell(
+                $this->firstColumnWidth,
+                10,
                 iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['product'], self::ICONV_CHARSET_INPUT)),
-                0, 0, 'L', 0
+                0,
+                0,
+                'L',
+                0
             );
             $this->Cell($this->columnSpacing, 10, '', 0, 0, 'L', 0);
             $this->Cell($width_other, 10, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['qty'], self::ICONV_CHARSET_INPUT)), 0, 0, 'C', 0);
             if (isset($this->vatField)) {
                 $this->Cell($this->columnSpacing, 10, '', 0, 0, 'L', 0);
-                $this->Cell($width_other, 10,
+                $this->Cell(
+                    $width_other,
+                    10,
                     iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['vat'], self::ICONV_CHARSET_INPUT)),
-                    0, 0, 'C', 0
+                    0,
+                    0,
+                    'C',
+                    0
                 );
             }
             if (isset($this->priceField)) {
                 $this->Cell($this->columnSpacing, 10, '', 0, 0, 'L', 0);
-                $this->Cell($width_other, 10,
+                $this->Cell(
+                    $width_other,
+                    10,
                     iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['price'], self::ICONV_CHARSET_INPUT)),
-                    0, 0,'C', 0
+                    0,
+                    0,
+                    'C',
+                    0
                 );
             }
             if (isset($this->discountField)) {
                 $this->Cell($this->columnSpacing, 10, '', 0, 0, 'L', 0);
-                $this->Cell($width_other, 10,
+                $this->Cell(
+                    $width_other,
+                    10,
                     iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['discount'], self::ICONV_CHARSET_INPUT)),
-                    0, 0, 'C', 0
+                    0,
+                    0,
+                    'C',
+                    0
                 );
             }
             
             if (isset($this->totalField)) {
                 $this->Cell($this->columnSpacing, 10, '', 0, 0, 'L', 0);
-                $this->Cell($width_other, 10,
+                $this->Cell(
+                    $width_other,
+                    10,
                     iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, mb_strtoupper($this->lang['total'], self::ICONV_CHARSET_INPUT)),
-                    0, 0,'C', 0
+                    0,
+                    0,
+                    'C',
+                    0
                 );
             }
             $this->Ln();

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -288,6 +288,7 @@ class InvoicePrinter extends FPDF
     {
         $p['item'] = $item;
         $p['description'] = $this->br2nl($description);
+        $p['quantity'] = $quantity;
 
         if ($vat !== false) {
             $p['vat'] = $vat;
@@ -297,10 +298,22 @@ class InvoicePrinter extends FPDF
             $this->vatField = true;
             $this->recalculateColumns();
         }
-        $p['quantity'] = $quantity;
-        $p['price'] = $price;
-        $p['total'] = $total;
-
+        if ($price !== false) {
+            $p['price'] = $price;
+            if (is_numeric($price)) {
+                $p['price'] = $this->price($price);
+            }
+            $this->priceField = true;
+            $this->recalculateColumns();
+        }
+        if ($total !== false) {
+            $p['total'] = $total;
+            if (is_numeric($total)) {
+                $p['total'] = $this->price($total);
+            }
+            $this->totalField = true;
+            $this->recalculateColumns();
+        }
         if ($discount !== false) {
             $this->firstColumnWidth = 58;
             $p['discount'] = $discount;
@@ -310,6 +323,7 @@ class InvoicePrinter extends FPDF
             $this->discountField = true;
             $this->recalculateColumns();
         }
+        
         $this->items[] = $p;
     }
 
@@ -850,6 +864,14 @@ class InvoicePrinter extends FPDF
         $this->columns = 4;
 
         if (isset($this->vatField)) {
+            $this->columns += 1;
+        }
+
+        if (isset($this->priceField)) {
+            $this->columns += 1;
+        }
+
+        if (isset($this->totalField)) {
             $this->columns += 1;
         }
 

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -593,7 +593,7 @@ class InvoicePrinter extends FPDF
                     0
                 );
             }
-            
+
             if (isset($this->totalField)) {
                 $this->Cell($this->columnSpacing, 10, '', 0, 0, 'L', 0);
                 $this->Cell(

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -323,7 +323,6 @@ class InvoicePrinter extends FPDF
             $this->discountField = true;
             $this->recalculateColumns();
         }
-        
         $this->items[] = $p;
     }
 

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -877,7 +877,7 @@ class InvoicePrinter extends FPDF
 
     private function recalculateColumns()
     {
-        $this->columns = 4;
+        $this->columns = 2;
 
         if (isset($this->vatField)) {
             $this->columns += 1;


### PR DESCRIPTION
Currently, only VAT and discount values are optional. With this change, price and total values will become optional as well. Useful for when you want to add a row with just some text between the actual items. For example, when one invoice consist of items from many orders, we can add those order headers in between items.
