### PR TITLE
Fix bug added in PR#46, and improved docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,17 +250,26 @@ Add a new product or service row to your document below the company and client i
 Invoice has automatic paging so there is absolutely no limit.
 
 ```php
-$invoice->addItem(name,description,amount,vat,price,discount,total);
+$invoice->addItem(name, description, quantity, vat, price, discount, total);
 ```
 
-- name {string} A string with the product or service name.
-- description {string} A string with the description with multi-line support. Use either `<br>` or `\n` to add a line-break.
-- amount {decimal} An integer with the amount of this item.
-- vat {string} or {decimal} Pass a string (e.g. "21%", or any other text you may like) or a decimal if you want to show an amount instead (e.g. 124.30)
-- price {decimal} A decimal for the unit price.
-- discount {string}, {decimal} or {boolean} Optional. Pass a string (e.g. "10%", or any other text you may like) or a decimal if you want to show an amount instead (e.g. 50.00) If you do not want to give discount just enter the boolean false in this field.
-_Note_: the final output will not show a discount column when all of the products haven't set a discount.
-- total {decimal} A decimal for the total product or service price.
+* `name` (string)  
+  A string with the product or service name.
+* `description` (string|false)  
+  A string with the description with multi-line support. Use either `<br>` or `\n` to add a line-break.
+* `quantity` (decimal|false)  
+  An integer with the quantity for of this line.
+* `vat` (string|decimal|false)   
+  Pass a string (e.g. "21%", or any other text you may like) or a decimal if you want to show an amount instead (e.g. 124.30).  A numeric value will be formatted as "money" automatically.
+* `price` (decimal|false)  
+  A decimal for the unit price.
+* `discount` (string|decimal|false)  
+  Pass a string (e.g. "10%", or any other text you may like) or a decimal if you want to show an amount instead (e.g. 50.00)
+  _Note_: the final output will not show a discount column unless any of the products haven't set a discount.
+* `total` (decimal|false)  
+  A decimal for the total product or service price.
+
+The fields `description`, `quantity`, `vat`, `price`, `discount` and `total` are all optinoal. To disable any of this for an invoice line, pass `false` for the corresponding argument.
 
 ### Item line description font size
 

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -951,30 +951,6 @@ class InvoicePrinter extends FPDF
         parent::_endpage();
     }
 
-    private function recalculateColumns()
-    {
-
-        if (isset($this->quantityField)) {
-            $this->columns += 1;
-        }
-
-        if (isset($this->vatField)) {
-            $this->columns += 1;
-        }
-
-        if (isset($this->priceField)) {
-            $this->columns += 1;
-        }
-
-        if (isset($this->totalField)) {
-            $this->columns += 1;
-        }
-
-        if (isset($this->discountField)) {
-            $this->columns += 1;
-        }
-    }
-
     private function getOtherColumnsWith()
     {
         if ($this->columns === 1) {

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -55,7 +55,7 @@ class InvoicePrinter extends FPDF
     public $display_tofrom = true;
     public $customHeaders = [];
     protected $displayToFromHeaders = true;
-    protected $columns;
+    protected $columns = 1;
 
     public function __construct($size = 'A4', $currency = '$', $language = 'en')
     {
@@ -71,8 +71,6 @@ class InvoicePrinter extends FPDF
         $this->setLanguage($language);
         $this->setDocumentSize($size);
         $this->setColor('#222222');
-
-        $this->recalculateColumns();
 
         parent::__construct('P', 'mm', [$this->document['w'], $this->document['h']]);
 
@@ -90,10 +88,6 @@ class InvoicePrinter extends FPDF
     private function setDocumentSize($dsize)
     {
         switch ($dsize) {
-            case 'A4':
-                $document['w'] = 210;
-                $document['h'] = 297;
-                break;
             case 'letter':
                 $document['w'] = 215.9;
                 $document['h'] = 279.4;
@@ -102,6 +96,7 @@ class InvoicePrinter extends FPDF
                 $document['w'] = 215.9;
                 $document['h'] = 355.6;
                 break;
+            case 'A4':
             default:
                 $document['w'] = 210;
                 $document['h'] = 297;
@@ -300,7 +295,8 @@ class InvoicePrinter extends FPDF
             $this->firstColumnWidth -= 12;
             $p['quantity'] = $quantity;
             $this->quantityField = true;
-            $this->recalculateColumns();
+
+            $this->columns++;
         }
 
         if ($vat !== false) {
@@ -309,24 +305,30 @@ class InvoicePrinter extends FPDF
                 $p['vat'] = $this->price($vat);
             }
             $this->vatField = true;
-            $this->recalculateColumns();
+
+            $this->columns++;
         }
+
         if ($price !== false) {
             $p['price'] = $price;
             if (is_numeric($price)) {
                 $p['price'] = $this->price($price);
             }
             $this->priceField = true;
-            $this->recalculateColumns();
+
+            $this->columns++;
         }
+
         if ($total !== false) {
             $p['total'] = $total;
             if (is_numeric($total)) {
                 $p['total'] = $this->price($total);
             }
             $this->totalField = true;
-            $this->recalculateColumns();
+
+            $this->columns++;
         }
+
         if ($discount !== false) {
             $this->firstColumnWidth -= 12;
             $p['discount'] = $discount;
@@ -334,8 +336,10 @@ class InvoicePrinter extends FPDF
                 $p['discount'] = $this->price($discount);
             }
             $this->discountField = true;
-            $this->recalculateColumns();
+
+            $this->columns++;
         }
+
         $this->items[] = $p;
     }
 
@@ -554,7 +558,7 @@ class InvoicePrinter extends FPDF
         }
         //Table header
         if (!isset($this->productsEnded)) {
-            $width_other = ($this->document['w'] - $this->margins['l'] - $this->margins['r'] - $this->firstColumnWidth - ($this->columns * $this->columnSpacing)) / ($this->columns - 1);
+            $width_other = $this->getOtherColumnsWith();
             $this->SetTextColor(50, 50, 50);
             $this->Ln(12);
             $this->SetFont($this->font, 'B', 9);
@@ -642,7 +646,7 @@ class InvoicePrinter extends FPDF
 
     public function Body()
     {
-        $width_other = ($this->document['w'] - $this->margins['l'] - $this->margins['r'] - $this->firstColumnWidth - ($this->columns * $this->columnSpacing)) / ($this->columns - 1);
+        $width_other = $this->getOtherColumnsWith();
         $cellHeight = 8;
         $bgcolor = (1 - $this->columnOpacity) * 255;
         if ($this->items) {
@@ -949,7 +953,6 @@ class InvoicePrinter extends FPDF
 
     private function recalculateColumns()
     {
-        $this->columns = 2;
 
         if (isset($this->quantityField)) {
             $this->columns += 1;
@@ -970,5 +973,15 @@ class InvoicePrinter extends FPDF
         if (isset($this->discountField)) {
             $this->columns += 1;
         }
+    }
+
+    private function getOtherColumnsWith()
+    {
+        if ($this->columns === 1) {
+            return $this->document['w'] - $this->margins['l'] - $this->margins['r'] - $this->firstColumnWidth - ($this->columns * $this->columnSpacing);
+        }
+
+        return ($this->document['w'] - $this->margins['l'] - $this->margins['r'] - $this->firstColumnWidth - ($this->columns * $this->columnSpacing))
+               / ($this->columns - 1);
     }
 }


### PR DESCRIPTION
BUGFIX: #46 introduced a bug in how columns were counted, and broke when a line had a "description" field.

Removed the "recalculateColumns()" method, since each "recalculation" was simply incrementing one the number of columns. We can initialize the number of columns as 1, and $this->columns++ when needed.

added a getOtherColumnsWith(), since this calculation is performed a couple of times in the class. since it was the source of the bug, better to fix it just once.

Fixed  README which didn't mention which fields were actually optional (including the one added in the previous PR).