### PR TITLE
Fix firstColumnWidth calculation

### DIFF
--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -62,7 +62,6 @@ class InvoicePrinter extends FPDF
         $this->items = [];
         $this->totals = [];
         $this->addText = [];
-        $this->firstColumnWidth = 82;
         $this->currency = $currency;
         $this->maxImageDimensions = [230, 130];
         $this->dimensions         = [61.0, 34.0];
@@ -71,6 +70,7 @@ class InvoicePrinter extends FPDF
         $this->setLanguage($language);
         $this->setDocumentSize($size);
         $this->setColor('#222222');
+        $this->firstColumnWidth = $this->document['w'] - $this->margins['l'] - $this->margins['r'];
 
         parent::__construct('P', 'mm', [$this->document['w'], $this->document['h']]);
 
@@ -294,7 +294,6 @@ class InvoicePrinter extends FPDF
         $p['quantity'] = $quantity;
 
         if ($quantity !== false) {
-            $this->firstColumnWidth -= 12;
             $p['quantity'] = $quantity;
             $this->quantityField = true;
 
@@ -332,7 +331,6 @@ class InvoicePrinter extends FPDF
         }
 
         if ($discount !== false) {
-            $this->firstColumnWidth -= 12;
             $p['discount'] = $discount;
             if (is_numeric($discount)) {
                 $p['discount'] = $this->price($discount);
@@ -344,8 +342,10 @@ class InvoicePrinter extends FPDF
 
         if (count($this->items) == 0) {
             $this->columns = $itemColumns;
+            $this->firstColumnWidth -= ($itemColumns - 1) * 20;
         } else {
             if ($itemColumns > $this->columns) {
+                $this->firstColumnWidth -= ($itemColumns - $this->columns) * 20;
                 $this->columns = $itemColumns;
             }
         }


### PR DESCRIPTION
Hi,

The firstColumnWidth variable is decreased by 12mm on each added item if the quantity and/or discount is set. With a lot of item the description column is not readable.

The initial value is now calculated by subtracting margins from the document width. For each added column the first one is decreased by a fixed value.

I don't know if you prefer to fix this value in a variable at the top of the script.

Best regards
Benoit