### PR TITLE
Fix page break issue when big item descriptions

### DIFF
--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -679,8 +679,8 @@ class InvoicePrinter extends FPDF
                         1
                     );
                     $descriptionHeight = $calculateHeight->getY() + $cellHeight + 2;
-                    $pageHeight = $this->document['h'] - $this->GetY() - $this->margins['t'] - $this->margins['t'];
-                    if ($pageHeight < 35) {
+                    $pageHeight = $this->document['h'] - $this->GetY() - $this->margins['t'] - $this->margins['t'] - $descriptionHeight;
+                    if ($pageHeight < 1) {
                         $this->AddPage();
                     }
                 }


### PR DESCRIPTION
Body() function was edited to fix page break causing line issue when having big descriptions on items.