### PR TITLE
Bugfix for PHP 8.1

### DIFF
--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -431,8 +431,8 @@ class InvoicePrinter extends FPDF
                          $this->GetStringWidth(mb_strtoupper($this->lang['due'], self::ICONV_CHARSET_INPUT))
                      )
                      - max(
-                         $this->GetStringWidth(mb_strtoupper($this->reference, self::ICONV_CHARSET_INPUT)),
-                         $this->GetStringWidth(mb_strtoupper($this->date, self::ICONV_CHARSET_INPUT))
+                         $this->GetStringWidth(mb_strtoupper((string)$this->reference, self::ICONV_CHARSET_INPUT)),
+                         $this->GetStringWidth(mb_strtoupper((string)$this->date, self::ICONV_CHARSET_INPUT))
                      );
 
         //Number

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -288,7 +288,7 @@ class InvoicePrinter extends FPDF
     public function addItem($item, $description, $quantity, $vat, $price, $discount, $total)
     {
         $itemColumns = 1;
-        
+
         $p['item'] = $item;
         $p['description'] = $this->br2nl($description);
         $p['quantity'] = $quantity;


### PR DESCRIPTION
This PR fixes the following PHP 8.1 deprecation error:
```
ERROR: mb_strtoupper(): Passing null to parameter #1 ($string) of type string is deprecated
```

Please go through this checklist, it is mandatory to accept your PR

- [x] Include the summary of your change.
- [x] Make sure all the tests are passing
- [x] Make sure StyleCI is passing
