### PR TITLE
Late static binding

### DIFF
--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -694,7 +694,7 @@ class InvoicePrinter extends FPDF
                 }
                 if ($item['description']) {
                     //Precalculate height
-                    $calculateHeight = new self();
+                    $calculateHeight = new static();
                     $calculateHeight->addPage();
                     $calculateHeight->setXY(0, 0);
                     $calculateHeight->SetFont($this->font, '', 7);


### PR DESCRIPTION
Use [late static binding](https://www.php.net/manual/en/language.oop5.late-static-bindings.php) so that an extending class is instantiated instead of the parent class.

Please go through this checklist, it is mandatory to accept your PR

- [x] Include the summary of your change.
- [x] Make sure all the tests are passing
- [x] Make sure StyleCI is passing
