### PR TITLE
Remove empty line when Item text is empty

### DIFF
--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -731,7 +731,7 @@ class InvoicePrinter extends FPDF
                     $resetX = $this->GetX();
                     $resetY = $this->GetY();
                     $this->SetTextColor(120, 120, 120);
-                    $this->SetXY($x, $this->GetY() + 8);
+                    (empty($item['item'])) ? $this->SetXY($x, $this->GetY() + 3) : $this->SetXY($x, $this->GetY() + 8);
                     $this->SetFont($this->font, '', $this->fontSizeProductDescription);
                     $this->MultiCell(
                         $this->firstColumnWidth,


### PR DESCRIPTION
Remove empty line when Item text is empty. Follow-up of #29 

Currently

![ItemEmpty01](https://user-images.githubusercontent.com/221351/65370806-1c841c00-dc5d-11e9-95fe-49de91978694.jpg)

After the fix

![ItemEmpty02](https://user-images.githubusercontent.com/221351/65370807-2148d000-dc5d-11e9-9609-1b6381a17e9f.jpg)

