### PR TITLE
Fixed PHP 8.2 deprecation warning

### DIFF
--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -80,6 +80,7 @@ class InvoicePrinter extends FPDF
     public $priceField;
     public $totalField;
     public $discountField;
+    public $vatField;
     public $productsEnded;
     protected $displayToFromHeaders = true;
     protected $columns = 1;


### PR DESCRIPTION
Fixed a PHP deprecation warning which fails to produce an invoice when using the `$vatField`.

- [x] Include the summary of your change.
- [x] Make sure all the tests are passing
- [x] Make sure StyleCI is passing
