### PR TITLE
:alien: fix: added 'time' key to italian

### DIFF
--- a/inc/languages/it.inc
+++ b/inc/languages/it.inc
@@ -1,6 +1,7 @@
 <?php
     $lang['number']   = 'Riferimento';
     $lang['date']     = 'Data di fatturazione';
+    $lang['time']     = 'Orario';
     $lang['due']      = 'Scadenza';
     $lang['to']       = 'Fatturazione per';
     $lang['from']     = 'Nostre informazioni';


### PR DESCRIPTION
The ```time``` key was missing from the translation file for the Italian language. This caused an error if the ```setTime()``` function was used.


<img width="812" alt="Error" src="https://github.com/artkonekt/pdf-invoice/assets/47114030/00122cd1-dfe7-420e-a459-921b9c6e975f">
